### PR TITLE
Fix the StateValidator and its broken usages

### DIFF
--- a/lib/kumo_dockercloud/deployment.rb
+++ b/lib/kumo_dockercloud/deployment.rb
@@ -27,7 +27,11 @@ module KumoDockerCloud
     end
 
     def wait_for_running_state
-      service_state_provider = lambda { docker_cloud_api.services.get(service_uuid) }
+      service_state_provider = lambda {
+        service = docker_cloud_api.services.get(service_uuid)
+        { name: service.name, state: service.state }
+      }
+
       StateValidator.new(service_state_provider).wait_for_state('Running', 240)
     end
 

--- a/lib/kumo_dockercloud/state_validator.rb
+++ b/lib/kumo_dockercloud/state_validator.rb
@@ -17,7 +17,7 @@ module KumoDockerCloud
         @stateful = state_provider.call
 
         if last_state != current_state
-          print "\n#{@stateful.name} is currently #{current_state}"
+          print "\n#{@stateful[:name]} is currently #{current_state}"
         else
           print "."
         end
@@ -41,7 +41,7 @@ module KumoDockerCloud
 
     def current_state
       return 'an unknown state' if @stateful.nil?
-      @stateful.state || 'an unknown state'
+      @stateful.fetch(:state, 'an unknown state')
     end
 
   end

--- a/spec/kumo_dockercloud/state_validator_spec.rb
+++ b/spec/kumo_dockercloud/state_validator_spec.rb
@@ -1,11 +1,12 @@
 require 'rspec'
+require 'spec_helper'
 
 describe KumoDockerCloud::StateValidator do
   describe '#wait_for_state' do
     subject { state_validator.wait_for_state('done', 1) }
     let(:state_validator) { described_class.new(state_provider) }
     let(:state_provider) { double('state_provider', call: service) }
-    let(:service) { instance_double(DockerCloud::Service, state: service_state, name: 'service name' ) }
+    let(:service) { { state: service_state, name: 'service name' } }
 
     context 'the right state' do
       let(:service_state) { 'done' }


### PR DESCRIPTION
StateValidator's interface uses Hashes, not objects from the DockerCloud API.
